### PR TITLE
Updated to support Firebase Admin SDK 5.x.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+resources/
 node_modules/
 **/npm-debug.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Piotr Kaminski
+Copyright (c) 2018 Piotr Kaminski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const request = require('request');
  * Fetches the keys of the current reference's children without also fetching all the contents,
  * using the Firebase REST API.
  * 
- * @param options An options object with the following items, all optional:
+ * @param {Reference} ref A Firebase database reference.
+ * @param {object} options An options object with the following items, all optional:
  *   - accessToken: a Google OAuth2 access token to pass to the REST API.
  *   - maxTries: the maximum number of times to try to fetch the keys, in case of transient errors
  *               (defaults to 1)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "firebase-childrenkeys",
-  "version": "0.1.2",
-  "description": "Adds a childrenKeys() method to Firebase that fetches children keys via the REST API",
+  "version": "1.0.0",
+  "description": "Fetch children keys of Firebase Database References via the REST API",
   "main": "index.js",
   "engines": {
     "node": ">=6.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node tests/runner.js"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,14 @@
   },
   "homepage": "https://github.com/pkaminski/firebase-childrenkeys",
   "dependencies": {
-    "firebase": "^2.2",
     "request": "^2.81.0"
+  },
+  "peerDependencies": {
+    "firebase-admin": "5.x.x"
+  },
+  "devDependencies": {
+    "firebase-admin": "5.x.x",
+    "googleapis": "^32.0.0",
+    "lodash": "^4.17.10"
   }
 }

--- a/tests/loadFirebase.js
+++ b/tests/loadFirebase.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const admin = require('firebase-admin');
+
+const pathToServiceAccount = path.resolve(__dirname, '../resources/serviceAccount.json');
+if (!fs.existsSync(pathToServiceAccount)) {
+  console.log(
+    `[ERROR] Firebase service account not found. Please place it in ${pathToServiceAccount}.`
+  );
+  process.exit(1);
+}
+
+const serviceAccount = require(pathToServiceAccount);
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: `https://${serviceAccount.project_id}.firebaseio.com`,
+});
+
+module.exports = admin;

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+const assert = require('assert');
+
+const utils = require('./utils');
+const admin = require('./loadFirebase');
+const childrenKeys = require('../index.js');
+
+const mockData = {
+  one: 1,
+  two: 'two',
+  three: true,
+  four: {
+    five: 5,
+    six: 6,
+    seven: 7,
+  },
+};
+
+console.log(`[INFO] Running tests...`)
+
+const rootRef = admin.database().ref();
+const testRef = rootRef.child('childrenKeys');
+
+testRef.set(mockData)
+  .then(() => {
+    return childrenKeys(testRef, {})
+  })
+  .then(() => utils.fetchAccessToken())
+  .then((accessToken) => childrenKeys(testRef, {accessToken}))
+  .then((keys) => {
+    assert(_.isEqual(keys.sort(), Object.keys(mockData).sort()), 'Children keys should return top-level keys');
+
+    console.log(`[INFO] All tests passed!`);
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.log(`[ERROR] Tests failed:`, error);
+    process.exit(1);
+  });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -34,15 +34,14 @@ module.exports.fetchAccessToken = () => {
   );
 
   // Fetch the Google OAuth2 access token.
-  return new Promise((resolve, reject) => {
-    jwtClient.authorize((error, tokens) => {
-      if (error) {
-        reject(new Error(`Error making request to generate access token: ${error.toString()}`));
-      } else if (tokens.access_token === null) {
-        reject(new Error(`Provided service account does not have permission to generate access tokens`));
-      } else {
-        resolve(tokens.access_token);
+  return jwtClient.authorize()
+    .then((tokens) => {
+      if (tokens.access_token === null) {
+        return Promise.reject(
+          new Error(`Provided service account does not have permission to generate access tokens`)
+        );
       }
+
+      return tokens.access_token;
     });
-  });
 }

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const {google} = require('googleapis');
+
+const pathToServiceAccount = path.resolve(__dirname, '../resources/serviceAccount.json');
+if (!fs.existsSync(pathToServiceAccount)) {
+  console.log(
+    `[ERROR] Firebase service account not found. Please place it in ${pathToServiceAccount}.`
+  );
+  process.exit(1);
+}
+
+const serviceAccount = require(pathToServiceAccount);
+
+/**
+ * Generates a Google OAuth2 access token for use authenticating to Firebase services, such as the
+ * Firebase Realtime Database REST API.
+ * 
+ * See https://firebase.google.com/docs/database/rest/auth#google_oauth2_access_tokens.
+ */
+module.exports.fetchAccessToken = () => {
+  // Define the required scopes.
+  const scopes = [
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/firebase.database"
+  ];
+
+  // Authenticate a JWT client with the service account.
+  const jwtClient = new google.auth.JWT(
+    serviceAccount.client_email,
+    null,
+    serviceAccount.private_key,
+    scopes
+  );
+
+  // Fetch the Google OAuth2 access token.
+  return new Promise((resolve, reject) => {
+    jwtClient.authorize((error, tokens) => {
+      if (error) {
+        reject(new Error(`Error making request to generate access token: ${error.toString()}`));
+      } else if (tokens.access_token === null) {
+        reject(new Error(`Provided service account does not have permission to generate access tokens`));
+      } else {
+        resolve(tokens.access_token);
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR updates this library to support the latest Firebase Admin SDK. It uses Google OAuth2 access tokens instead of the old Firebase custom auth tokens. It now exports a single method instead of patching the `Firebase` prototype. Usage can be seen in the test runner.

Other comments inline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pkaminski/firebase-childrenkeys/1)
<!-- Reviewable:end -->
